### PR TITLE
Vertical space between "Normalize" and "RLE slider"

### DIFF
--- a/inst/website/ui.R
+++ b/inst/website/ui.R
@@ -129,6 +129,9 @@ shinyUI(
                 actionButton("normalizeButton", 
                              HTML(paste(icon("cog", lib = "glyphicon"), 
                                         "Normalize files"))),
+				tags$br(),
+				tags$hr(),
+								
 				sliderInput("rle.iqr.threshold",
                             "Keep samples with RLE IQR less than:",
                             step = 0.01,


### PR DESCRIPTION
Added extra vertical space between the normalize button and RLE IQR
slider
